### PR TITLE
use bencode gem instead of bencode_ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Firecracker.calculate(torrent.bdecode)
 
 ## Helper methods
 
-Ingoing argument (`torrent`) is from now on a [String#bdecode](https://github.com/naquad/bencode_ext) hash.
+Ingoing argument (`torrent`) is from now on a [String#bdecode](https://github.com/dasch/ruby-bencode) hash.
 
 ``` ruby
-require "bencode_ext"
+require "bencode"
 torrent = File.read("path/to/file.torrent").bdecode
 ```
 
@@ -73,8 +73,8 @@ The hash being passed is a [info_hash](http://wiki.theory.org/BitTorrent_Tracker
 
 You can in theory pass up to 72 hashes in one request.
 
-Keep in mind that if one of the passed hashes is invalid or doesn't exist, the requested server might return 404 or 400.  
-It's therefore recommended to make one request for each hash. 
+Keep in mind that if one of the passed hashes is invalid or doesn't exist, the requested server might return 404 or 400.
+It's therefore recommended to make one request for each hash.
 
 ### TCP
 

--- a/firecracker.gemspec
+++ b/firecracker.gemspec
@@ -14,13 +14,13 @@ Gem::Specification.new do |gem|
   gem.name          = "firecracker"
   gem.require_paths = ["lib"]
   gem.version       = Firecracker::VERSION
-  
+
   gem.add_dependency("rest-client")
-  gem.add_dependency("bencode_ext")
-  
+  gem.add_dependency("bencode")
+
   gem.add_development_dependency("vcr")
-  gem.add_development_dependency("rspec")  
+  gem.add_development_dependency("rspec")
   gem.add_development_dependency("webmock")
-  
+
   gem.required_ruby_version = "> 1.9.0"
 end

--- a/lib/firecracker/base.rb
+++ b/lib/firecracker/base.rb
@@ -1,4 +1,4 @@
-require "bencode_ext"
+require "bencode"
 require "timeout"
 
 module Firecracker
@@ -20,7 +20,7 @@ module Firecracker
         hashes: []
       }.merge(args)
     end
-    
+
     #
     # @return Do we have everyting that's needed
     #  to do the request.
@@ -31,21 +31,21 @@ module Firecracker
         @options[:hashes].count.between?(1, 72)
       ].all?
     end
-    
+
     #
     # @return Should we print debug ouput?
     #
     def debug?
       @options[:debug]
     end
-    
+
     #
     # @return Array<String> A list of hashes
     #
     def hashes
       @options[:hashes]
     end
-    
+
     #
     # @return Integer Global timeout limit
     #


### PR DESCRIPTION
Firecracker does not seem to parse the torrent file correctly any more. The issue seems to be with the `bencode_ext` gem. Replacing it with `bencode` fixes the issue. Please review and merge if you think it looks good. 

Thanks